### PR TITLE
DDFSAL-132 - Add 404 page with content from static HTML file

### DIFF
--- a/app/not-found.tsx
+++ b/app/not-found.tsx
@@ -1,0 +1,9 @@
+import HtmlContent from "@/components/HtmlContent";
+
+export default function Home() {
+  return (
+    <main>
+      <HtmlContent src="/content/main.html" />
+    </main>
+  );
+}

--- a/components/HtmlContent.tsx
+++ b/components/HtmlContent.tsx
@@ -1,0 +1,14 @@
+// This component fetches a static HTML file and renders it.
+// https://vercel.com/guides/loading-static-file-nextjs-api-route?utm_source=chatgpt.com
+import { promises as fs } from "fs";
+import path from "path";
+interface HtmlContentProps {
+  src: string;
+}
+
+export default async function HtmlContent({ src }: HtmlContentProps) {
+  const filePath = path.join(process.cwd(), src);
+  const content = await fs.readFile(filePath, "utf-8");
+
+  return <div dangerouslySetInnerHTML={{ __html: content }} />;
+}

--- a/content/main.html
+++ b/content/main.html
@@ -1,0 +1,9 @@
+<h1>Ereolen.dk er lukket.</h1>
+<p>
+  Men bare rolig – du kan stadig låne, læse og reservere digitale materialer hos
+  dit lokale bibliotek!
+</p>
+<p>
+  Klik på knappen herunder for at finde dit nærmeste bibliotek og få adgang til
+  e-bøger, lydbøger og andre digitale medier.
+</p>


### PR DESCRIPTION
This PR introduces a custom 404 page to gracefully handle legacy ereolen.dk URLs. It leverages Next.js’s built-in not-found.tsx routing behavior and incorporates a simple CMS approach by serving static HTML content. This setup allows content editors to easily update texts without touching the application code—just edit the HTML directly in the github repository.
