### PR TITLE
Migrate from GitHub Pages to custom domain ereolen.dk

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ Dette projekt er bygget for at sikre, at gamle links til Ereolen materialer på 
 Den bruges f.eks. til at omskrive links fra `/ting/object/:id` til den "nye" struktur `/work/work-of::id`.
 
 Siden kan ses her [https://reload.github.io/ereolen/](https://reload.github.io/ereolen/)
+Ny adresse: [https://ereolen.dk](https://ereolen.dk)
 
 ---
 

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -27,7 +27,7 @@ const sourceSansPro = localFont({
 });
 
 export const metadata: Metadata = {
-  metadataBase: new URL("https://reload.github.io/ereolen/"),
+  metadataBase: new URL("https://ereolen.dk"),
   title: "eReolen",
   description:
     "eReolen er flyttet til din lokale bibliotekshjemmeside. Vælg dit bibliotek her.",
@@ -35,14 +35,14 @@ export const metadata: Metadata = {
     title: "eReolen",
     description:
       "eReolen er flyttet til din lokale bibliotekshjemmeside. Vælg dit bibliotek her.",
-    images: ["/ereolen_logo_some.png"],
+    images: [addBasePath("/ereolen_logo_some.png")],
   },
   twitter: {
     card: "summary_large_image",
     title: "eReolen",
     description:
       "eReolen er flyttet til din lokale bibliotekshjemmeside. Vælg dit bibliotek her.",
-    images: ["/ereolen_logo_some.png"],
+    images: [addBasePath("/ereolen_logo_some.png")],
   },
 };
 

--- a/lib/basePath.ts
+++ b/lib/basePath.ts
@@ -1,4 +1,4 @@
-const basePath = process.env.NODE_ENV === "production" ? "/ereolen" : "";
+const basePath = process.env.NODE_ENV === "production" ? "" : "";
 
 export const addBasePath = (path: string) => {
   return `${basePath}${path}`;

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -6,9 +6,9 @@ export function cn(...inputs: ClassValue[]) {
 }
 
 export function buildRedirectParam(pathname: string, search: string): string {
-  const basePath = pathname.startsWith("/ereolen") ? "/ereolen" : "";
+  // For custom domain - no basePath prefix needed
   const fullPath = pathname + search;
-  return `${basePath}/?from=${encodeURIComponent(fullPath)}`;
+  return `/?from=${encodeURIComponent(fullPath)}`;
 }
 
 type BuildRedirectUrlParams = {

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,10 +1,10 @@
 import type { NextConfig } from "next";
 
-const basePath = process.env.NODE_ENV === "production" ? "/ereolen" : "";
+const basePath = process.env.NODE_ENV === "production" ? "" : "";
 
 const nextConfig: NextConfig = {
   output: "export",
-  // Prefix routes and assets for GitHub Pages under /ereolen
+  // No prefix needed for custom domain
   basePath: basePath,
   assetPrefix: basePath,
   // Ensure static export generates trailing slashes for directories


### PR DESCRIPTION
Remove /ereolen basePath configuration for production builds since we're moving from reload.github.io/ereolen/ to the custom domain ereolen.dk.

The redirect service will now handle legacy eReolen URLs directly on the custom domain without path prefixes, properly redirecting users to their local library websites when they access old ting/object/ URLs.